### PR TITLE
bug: fix archive inline includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - archive: Resolve `.cls` vs `.bst` ambiguity and include nested local dependencies.
+- archive: Correctly handle `\input` commands wrapped inline by another commands
 
 ### Tests
 - archive: Add coverage for `\documentclass` resolution.

--- a/src/luci/archive.py
+++ b/src/luci/archive.py
@@ -150,11 +150,9 @@ def flatten_latex(
                 scratch=scratch,
             )
             dependencies.update(deps)
-            flattened_lines.append(included_text)
-
-            # Add any trailing content after the command on the same line
-            if post.strip():
-                flattened_lines.append(post + "\n")
+            # Preserve any prefix and postfix text on the line (e.g. macro wrappers)
+            # by reconstructing the full line with the flattened include inserted.
+            flattened_lines.append(pre + included_text + post + "\n")
         else:
             flattened_lines.append(line)
 

--- a/src/luci/bibtools.py
+++ b/src/luci/bibtools.py
@@ -70,7 +70,6 @@ def run_bibtex_tidy_dedupe(input_bib: Path) -> tuple[str, dict[str, str]]:
     # Parse duplicate mappings from stderr
     key_updates = {}
     for line in result.stdout.splitlines():
-        print(line)
         if m := DUPLICATE_RE.search(line):
             old_key, new_key = m.groups()
             key_updates[old_key] = new_key


### PR DESCRIPTION
Fix handling of inline includes when archiving

```latex
\title{\input{frontmatter/title.tex}}
```
